### PR TITLE
Update Brother printer iOS SDK to 3.1.7.

### DIFF
--- a/BRPtouchPrinterKit.podspec
+++ b/BRPtouchPrinterKit.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "BRPtouchPrinterKit"
-  s.version      = "3.1.6"
+  s.version      = "3.1.7"
   s.summary      = "Brother Print SDK for iPhone/iPad."
 
   s.description  = <<-DESC
@@ -73,7 +73,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/envoy/BRPtouchPrinterKit.git", :tag => "3.1.6" }
+  s.source       = { :git => "https://github.com/envoy/BRPtouchPrinterKit.git", :tag => "3.1.7" }
 
 
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchBLEManager.h
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchBLEManager.h
@@ -1,0 +1,28 @@
+//
+//  BRPtouchBLEManager.h
+//  BRPtouchPrinterKit
+//
+//  Copyright (c) 2017-2018 Brother Industries, Ltd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "BRPtouchDeviceInfo.h"
+#import <CoreBluetooth/CoreBluetooth.h>
+
+@interface BRPtouchBLEManager : NSObject
+
++ (BRPtouchBLEManager *)sharedManager;
+
+/**
+ Start searching BLE printers
+ @return NO if BLE is not available, otherwise YES
+ */
+typedef void (^BRBLEManagerSearchCompletionHandler)(BRPtouchDeviceInfo *deviceInfo);
+- (BOOL)startSearchWithCompletionHandler:(BRBLEManagerSearchCompletionHandler)handler;
+
+/**
+ Stop searching BLE printers
+ */
+- (void)stopSearch;
+
+@end

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchBluetoothManager.h
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchBluetoothManager.h
@@ -2,7 +2,7 @@
 //  BRPtouchBluetoothManager.h
 //  BRSearchModule
 //
-//  Copyright (c) 2017 Brother. All rights reserved.
+//  Copyright (c) 2015-2018 Brother Industries, Ltd. All rights reserved.
 //
 
 

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchDeviceInfo.h
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchDeviceInfo.h
@@ -2,7 +2,7 @@
 //  BRPtouchDevice.h
 //  BRSearchModule
 //
-//  Copyright (c) 2017 Brother. All rights reserved.
+//  Copyright (c) 2015-2018 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -16,6 +16,7 @@
 @property	(copy,nonatomic)NSString*	strSerialNumber;
 @property	(copy,nonatomic)NSString*	strNodeName;
 @property	(copy,nonatomic)NSString*	strMACAddress;
+@property   (copy,nonatomic)NSString*   strBLEAdvertiseLocalName;
 
 - (NSString *)description;
 

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchLabelInfoStatus.h
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchLabelInfoStatus.h
@@ -1,0 +1,117 @@
+//
+//  BRPtouchLabelInfo.h
+//  BRPtouchPrinterKit
+//
+//  Copyright (c) 2016-2018 Brother Industries, Ltd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, LabelIdType) {
+    
+    //QL
+    LabelIdTypeW17H54 = 0x01,
+    LabelIdTypeW17H87 = 0x02,
+    LabelIdTypeW23H23 = 0x03,
+    LabelIdTypeW29H42 = 0x04,
+    LabelIdTypeW29H90 = 0x05,
+    LabelIdTypeW38H90 = 0x06,
+    LabelIdTypeW39H48 = 0x07,
+    LabelIdTypeW52H29 = 0x08,
+    LabelIdTypeW62H29 = 0x09,
+    LabelIdTypeW62H100 = 0x0a,
+    LabelIdTypeW12 = 0x0b,  //also used in PT
+    LabelIdTypeW29 = 0xc,
+    LabelIdTypeW38 = 0xd,
+    LabelIdTypeW50 = 0xe,
+    LabelIdTypeW54 = 0xf,
+    LabelIdTypeW62 = 0x10,
+    LabelIdTypeW60H86 = 0x11,
+    
+    //PT
+    LabelIdTypeW3_5 = 0x12,
+    LabelIdTypeW6 = 0x13,
+    LabelIdTypeW9 = 0x14,
+    LabelIdTypeW18 = 0x15,
+    LabelIdTypeW24 = 0x16,
+    LabelIdTypeHS_W6 = 0x17,
+    LabelIdTypeHS_W9 = 0x18,
+    LabelIdTypeHS_W12 = 0x19,
+    LabelIdTypeHS_W18 = 0x1a,
+    LabelIdTypeHS_W24 = 0x1b,
+    LabelIdTypeW36 = 0x1c,
+    
+    LabelIdTypeR6_5 = 0x1d,
+    LabelIdTypeR6_0 = 0x1f,
+    LabelIdTypeR5_0 = 0x20,
+    LabelIdTypeR4_0 = 0x21,
+    LabelIdTypeR3_5 = 0x22,
+    LabelIdTypeR3_0 = 0x23,
+    LabelIdTypeR2_5 = 0x24,
+    
+    LabelIdTypeFLE_W21H45 = 0x25,
+    
+    //QL-8対応
+    LabelIdTypeW62RB = 0x26,
+    LabelIdTypeW54H29 = 0x27,
+
+    //QL_1100
+    LabelIdTypeW102 = 0x28,
+    LabelIdTypeW102H51 = 0x29,
+    LabelIdTypeW102H152 = 0x30,
+    LabelIdTypeW103 = 0x31,
+    LabelIdTypeW103H164 = 0x32,
+    LabelIdTypeDT_W90 = 0x33,
+    LabelIdTypeDT_W102 = 0x34,
+    LabelIdTypeDT_W102H51 = 0x35,
+    LabelIdTypeDT_W102H152 = 0x36,
+
+    LabelIdTypeLABEL_MAX
+    
+};
+
+typedef NS_ENUM(NSUInteger, ColorType) {
+    WHITE = 0x01,
+    OTHERS,
+    CLEAR,
+    RED,
+    BLUE,
+    YELLOW,
+    GREEN,
+    BLACK,
+    CLEAR_WHITE,
+    GOLD = 0x0A ,
+    GOLD_PREMIUM = 0x0B,
+    SILVER_PREMIUM = 0x0C,
+    OTHERS_PREMIUM = 0x0D,
+    OTHERS_MASKING = 0x0E,
+    MATTE_WHITE = 0x20,
+    MATTE_CLEAR,
+    MATTE_SILVER,
+    SATIN_GOLD,
+    SATIN_SILVER = 0x24,
+    BLUE_WHITE = 0x30,
+    RED_WHITE = 0x31,
+    FLOURESCENT_ORANGE = 0x40,
+    FLOURESCENT_YELLOW = 0x41,
+    BERRY_PINK = 0x50,
+    LIGHT_GLAY,
+    LIME_GREEN = 0x52,
+    FABRIC_YELLOW = 0x60,
+    FABRIC_PINK = 0x61,
+    FABRIC_BLUE = 0x62,
+    TUBE_WHITE = 0x70,
+    SELF_WHITE = 0x80,
+    FLEXIBLE_WHITE = 0x90,
+    FLEXIBLE_YELLOW = 0x91,
+    CLEANING = 0xF0,
+    STENCIL = 0xF1,
+    UNSUPPORT = 0xFF,
+};
+
+@interface BRPtouchLabelInfoStatus : NSObject
+@property (nonatomic) LabelIdType labelID;
+@property (nonatomic) ColorType labelColor;
+@property (nonatomic) ColorType fontColor;
+
+@end

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchLabelParam.h
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchLabelParam.h
@@ -1,0 +1,27 @@
+//
+//  BRPtouchLabelParam.h
+//  BRPtouchPrinterKit
+//
+//  Copyright (c) 2016-2018 Brother Industries, Ltd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface BRPtouchLabelParam : NSObject
+@property (nonatomic) unsigned int  paperID;
+@property (nonatomic, copy) NSString* paperName;
+@property (nonatomic) unsigned int  paperSize;
+@property (nonatomic) unsigned int  pinOffsetLeft;
+@property (nonatomic) unsigned int  pinOffsetRight;
+@property (nonatomic) unsigned int  physicalOffsetX;
+@property (nonatomic) unsigned int  physicalOffsetY;
+@property (nonatomic) unsigned int paperWidth;         //dot
+@property (nonatomic) float paperWidth_mm;     //mm
+@property (nonatomic) unsigned int paperLength;    //dot
+@property (nonatomic) float paperLength_mm;    //mm
+@property (nonatomic) unsigned int  imageAreaWidth;   //dot
+@property (nonatomic) unsigned int  imageAreaWidth_mm;   //mm
+@property (nonatomic) unsigned int  imageAreaLength;  //dot
+@property (nonatomic) unsigned int  imageAreaLength_mm;  //mm
+
+@end

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchNetworkManager.h
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchNetworkManager.h
@@ -2,7 +2,7 @@
 //  BRPtouchNetwork.h
 //  BRPtouchPrinterKit
 //
-//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2012-2018 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrintInfo.h
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrintInfo.h
@@ -2,7 +2,7 @@
 //  BRPtouchPrintInfo.h
 //  BRPtouchPrinterKit
 //
-//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2012-2018 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -11,8 +11,10 @@
 #define OPTION_CUTATEND		0x00000002
 
 #define PRINT_ORIGINAL		0x00
-#define PRINT_FIT			0x01
+#define PRINT_FIT			0x01 // Deprecated
 #define PRINT_SCALE			0x02
+#define PRINT_FIT_TO_PAGE	0x03
+#define PRINT_FIT_TO_PAPER	0x04
 
 #define ORI_LANDSCAPE		0x00
 #define ORI_PORTRATE		0x01
@@ -92,12 +94,12 @@
 
 
 @property	(copy,nonatomic)NSString*			strPaperName;
-@property	(assign,nonatomic)unsigned long		ulOption;
 @property	(assign,nonatomic)int				nPrintMode;
 @property	(assign,nonatomic)double            scaleValue;
 @property	(assign,nonatomic)int				nDensity;
 @property	(assign,nonatomic)int				nOrientation;
 @property	(assign,nonatomic)int				nHalftone;
+@property	(assign,nonatomic)int				nHalftoneBinaryThreshold;
 @property	(assign,nonatomic)int				nHorizontalAlign;
 @property	(assign,nonatomic)int				nVerticalAlign;
 @property	(assign,nonatomic)int				nPaperAlign;
@@ -126,5 +128,7 @@
 @property   (assign,nonatomic)int               nPrintQuality;
 @property   (assign,nonatomic)BOOL              bMode9;
 @property   (assign,nonatomic)BOOL              bRawMode;
+@property   (assign,nonatomic)BOOL              bBanishMargin;
+@property   (assign,nonatomic)BOOL              bUseLegacyHalftoneEngine;
 
 @end

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterData.h
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterData.h
@@ -2,9 +2,8 @@
 //  BRPtouchPrinterData.h
 //  BRPtouchPrinterKit
 //
-//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2012-2018 Brother Industries, Ltd. All rights reserved.
 //
-
 #import <Foundation/Foundation.h>
 
 @interface BRPtouchPrinterData : NSObject

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterKit.h
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterKit.h
@@ -2,13 +2,14 @@
 //  BRPtouchPrinterKit.h
 //  BRPtouchPrinterKit
 //
-//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2012-2018 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 #import "BRPtouchPrinter.h"
 #import "BRPtouchNetworkManager.h"
 #import "BRPtouchBluetoothManager.h"
+#import "BRPtouchBLEManager.h"
 #import "BRPtouchDeviceInfo.h"
 
 @interface BRPtouchPrinterKit : NSObject

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterStatus.h
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Headers/BRPtouchPrinterStatus.h
@@ -2,7 +2,7 @@
 //  BRPtouchPrinterStatus.h
 //  BRPtouchPrinterKit
 //
-//  Copyright (c) 2017 Brother Industries, Ltd. All rights reserved.
+//  Copyright (c) 2016-2018 Brother Industries, Ltd. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -38,8 +38,21 @@ typedef struct _PTSTATUSINFO {
     Byte	byNoUse[2];                 // Not Use
 } PTSTATUSINFO, *LPPTSTATUSINFO;
 
+typedef NS_ENUM(NSInteger, BRPtouchPrinterStatusBatteryTernary) {
+    BRPtouchPrinterStatusBatteryTernaryUnknown = -1,
+    BRPtouchPrinterStatusBatteryTernaryYes = 1,
+    BRPtouchPrinterStatusBatteryTernaryNo = 0,
+};
 @interface BRPtouchPrinterStatus : NSObject
-@property (nonatomic) PTSTATUSINFO *statusInfo;
-@property (nonatomic) int16_t batteryLevel;
+@property (nonatomic) PTSTATUSINFO statusInfo;
+
+// battery
+@property (nonatomic) int32_t batteryResidualQuantityLevel;
+@property (nonatomic) int32_t maxOfBatteryResidualQuantityLevel;
+
+@property (nonatomic) BRPtouchPrinterStatusBatteryTernary isACConnected;
+@property (nonatomic) BRPtouchPrinterStatusBatteryTernary isBatteryMounted;
+
+@property (nonatomic) int16_t batteryLevel __deprecated;
 
 @end

--- a/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Resources/Info.plist
+++ b/Frameworks/BRPtouchPrinterKit.framework/Versions/A/Resources/Info.plist
@@ -19,13 +19,13 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.6</string>
+	<string>3.1.7</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>55</string>
+	<string>70</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright (C) 2012-2018 Brother Industries, Ltd. All rights reserved.</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Changelog from Brother:

```
Ver.3.1.7	06/06/2018
Add RJ-4230B to the target printers.
```

Source:  http://www.brother.co.jp/eng/dev/mobilesdk/ios/index.aspx#history